### PR TITLE
Silence join warnings causing problems in tests

### DIFF
--- a/R/plot.functions.R
+++ b/R/plot.functions.R
@@ -549,12 +549,12 @@ timeplot <- function(network, level="treatment", plotby="arm", link="identity", 
 
     if (link=="identity") {
       diffs <- diffs %>%
-        dplyr::inner_join(diffs, by=c("studyID", "time")) %>%
+        dplyr::inner_join(diffs, by=c("studyID", "time"), multiple = "all") %>%
         dplyr::filter(.data$treatment.x < .data$treatment.y) %>%
         dplyr::mutate(pairDiff = .data$y.y - .data$y.x)
     } else if (link=="rom") {
       diffs <- diffs %>%
-        dplyr::inner_join(diffs, by=c("studyID", "time")) %>%
+        dplyr::inner_join(diffs, by=c("studyID", "time"), multiple = "all") %>%
         dplyr::filter(.data$treatment.x < .data$treatment.y) %>%
         dplyr::mutate(pairDiff = log(.data$y.y/.data$y.x))
     } else if (link=="smd") {
@@ -563,7 +563,7 @@ timeplot <- function(network, level="treatment", plotby="arm", link="identity", 
       }
 
       diffs <- diffs %>%
-        dplyr::inner_join(diffs, by=c("studyID", "time")) %>%
+        dplyr::inner_join(diffs, by=c("studyID", "time"), multiple = "all") %>%
         dplyr::filter(.data$treatment.x < .data$treatment.y) %>%
         dplyr::mutate(
           var.y = (.data$se.y * (.data$n.y)^0.5)^2,


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. We can go ahead and set this argument. In dplyr <1.1.0 it just won't do anything. This allows your tests to pass in both dev and CRAN dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!